### PR TITLE
Fix input check for operator parallelism

### DIFF
--- a/flink-scaling-scripts/change-wordcount-parallelism.sh
+++ b/flink-scaling-scripts/change-wordcount-parallelism.sh
@@ -26,7 +26,7 @@ fi
 JOB_ID=$1
 
 ### operators and parallelism
-if [ "$1" == "" ]; then
+if [ "$2" == "" ]; then
     echo "Please provide operators and their initial parallelism as the second argument"
     exit 1
 fi


### PR DESCRIPTION
A brief fix to the input check on change-wordcount-parallelism.sh.